### PR TITLE
Set minimum size of News link on homepage.

### DIFF
--- a/_layouts/about.html
+++ b/_layouts/about.html
@@ -43,7 +43,7 @@ layout: default
 
           <!-- News -->
           {% if page.news and site.announcements.enabled -%}
-            <h2><a href="{{ '/news/' | relative_url }}" style="color: inherit;">News</a></h2>
+            <h2><a href="{{ '/news/' | relative_url }}" style="color: inherit; min-width: 44px; min-height: 44px; display: inline-block;">News</a></h2>
             {%- include news.html limit=true %}
           {%- endif %}
 


### PR DESCRIPTION
This should fix another instance of the SiteImprove issue "Interactive element does not meet enhanced size".